### PR TITLE
claude/fix-chezmoi-installation-r8bic

### DIFF
--- a/home/.chezmoiremove.tmpl
+++ b/home/.chezmoiremove.tmpl
@@ -9,3 +9,11 @@
 # Example:
 #   .old_tool_config
 #   {{ if eq .chezmoi.os "darwin" }}.macos_only_file{{ end }}
+
+# Cleanup from machines bootstrapped against an early iteration of the chezmoi
+# migration (#17) before .chezmoiroot existed. Without that redirect, chezmoi
+# treated the repo root as the source and copied these top-level paths into ~.
+# They belong in the chezmoi working tree only, never in $HOME.
+CLAUDE.md
+modules
+scripts


### PR DESCRIPTION
Earlier iterations of #17 didn't ship .chezmoiroot, so chezmoi treated
the repo root as the source and copied scripts/, modules/, and CLAUDE.md
straight into $HOME on machines bootstrapped during that window. Add
them to .chezmoiremove.tmpl so the next apply cleans them up everywhere.

https://claude.ai/code/session_013Y4pSk8EX71EfYz2NDKf2K