### PR TITLE
Add setupGit toggle to skip managing git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Asked at init and cached; re-prompt via `chezmoi init --prompt`.
 | `installDocker`       | Docker via get.docker.com (Linux only).                  |
 | `installClaudeCode`   | Claude Code via `claude.ai/install.sh` (Linux only; macOS gets it via brew). |
 | `useGitea`            | Enable the post-install reminder for `scripts/post/setup_gitea.sh`. |
+| `setupGit`            | Manage `~/.gitconfig` and `~/.config/git/*` (user, SSH signing, global ignore). Off for machines that don't need git. |
 
-Plus two string prompts: `email` and `name` for git config.
+Plus three string prompts asked only when `setupGit` is on: `email`, `name`, and `githubUser` for git config.
 
 ## Layout
 

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -3,9 +3,16 @@
   `chezmoi init --prompt` to re-prompt with the current values as defaults.
 */ -}}
 
-{{- $email      := promptStringOnce . "email"      "Git email"      "git@eteiss.org" -}}
-{{- $name       := promptStringOnce . "name"       "Git name"       "Eliott Teissonniere" -}}
-{{- $githubUser := promptStringOnce . "githubUser" "GitHub username" "ETeissonniere" -}}
+{{- $setupGit := promptBoolOnce . "setupGit" "Configure git (user, signing, global ignore)" true -}}
+
+{{- $email      := "" -}}
+{{- $name       := "" -}}
+{{- $githubUser := "" -}}
+{{- if $setupGit -}}
+{{-   $email      = promptStringOnce . "email"      "Git email"       "git@eteiss.org" -}}
+{{-   $name       = promptStringOnce . "name"       "Git name"        "Eliott Teissonniere" -}}
+{{-   $githubUser = promptStringOnce . "githubUser" "GitHub username" "ETeissonniere" -}}
+{{- end -}}
 
 {{- $isDesktop := promptBoolOnce . "isDesktop" "Desktop workstation (not a VM/server)" true -}}
 {{- $useGitea  := promptBoolOnce . "useGitea"  "Use a (self-hosted) Gitea instance"    false -}}
@@ -45,6 +52,7 @@ sourceDir = {{ .chezmoi.workingTree | quote }}
 {{- end }}
 
 [data]
+    setupGit            = {{ $setupGit }}
     email               = {{ $email | quote }}
     name                = {{ $name  | quote }}
     githubUser          = {{ $githubUser | quote }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -5,3 +5,8 @@
 {{ if eq .chezmoi.os "darwin" -}}
 dot_tmux.conf
 {{- end }}
+
+{{ if not .setupGit -}}
+.gitconfig
+.config/git/**
+{{- end }}


### PR DESCRIPTION
## Summary
- New `setupGit` boolean prompt (default `true`) in `home/.chezmoi.toml.tmpl`; when off, the `email` / `name` / `githubUser` prompts are skipped too.
- `.chezmoiignore` now excludes `~/.gitconfig` and `~/.config/git/**` when `setupGit` is false, which also avoids the `gitHubKeys` API call in `allowed_signers.tmpl`.
- README toggle table updated.

## Test plan
- [x] `chezmoi apply --dry-run` succeeds with `setupGit = true` (existing behavior, all three git files managed).
- [x] `chezmoi apply --dry-run` succeeds with `setupGit = false` (no git files managed, no GitHub API call).
- [ ] CI (`.github/workflows/verify.yml`) passes — it uses `--promptDefaults`, which keeps `setupGit = true`, so the existing render path is unchanged.

https://claude.ai/code/session_019jCZygdNPow9A8cGR534yk