### PR TITLE
claude/chezmoi-purge-option-IFxdF

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Managed by [chezmoi](https://www.chezmoi.io/). Module selection is interactive a
 ## Quick start
 
 ```sh
-sh -c "$(curl -fsLS get.chezmoi.io/lb)" -- init --apply ETeissonniere
+sh -c "$(curl -fsLS get.chezmoi.io)" -- -P init --apply ETeissonniere
 ```
 
-The `/lb` variant installs chezmoi to `~/.local/bin` (which the rendered zsh config puts on PATH for you).
+`-P`/`--purge-binary` removes the bootstrap chezmoi binary once `init --apply` finishes; the persistent binary is installed via Homebrew as part of the run.
 
 That installs chezmoi, clones this repo into its source directory, asks a short list of yes/no questions (desktop? Docker? social apps?…), and applies everything.
 

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -6,6 +6,7 @@ packages:
   common:
     brews:
       - btop
+      - chezmoi
       - eza
       - fd
       - fzf


### PR DESCRIPTION
Switch the quick-start to `sh ... -- -P init --apply` so the bootstrap
chezmoi binary is removed once init finishes. The persistent chezmoi
binary is now owned by Homebrew via the common brews manifest.