### PR TITLE
claude/fix-duplicate-pr-workflows-KiwQQ

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,6 +2,7 @@ name: Verify
 
 on:
   push:
+    branches: [master]
   pull_request:
 
 permissions:


### PR DESCRIPTION
Prevents duplicate workflow runs when a PR is opened from a branch in
this repo — previously both push and pull_request events triggered.