### PR TITLE
claude/skip-postinstall-git-disabled-oVyCW

### DIFF
--- a/home/run_after_99-post-install-checks.sh.tmpl
+++ b/home/run_after_99-post-install-checks.sh.tmpl
@@ -5,6 +5,7 @@ set -euo pipefail
 
 pending=()
 
+{{ if .setupGit -}}
 if [[ -f "$HOME/.ssh/id_ed25519.pub" ]] && command -v gh >/dev/null 2>&1; then
   # Compare by base64 data (field 2) since GitHub strips the comment on upload.
   pub_key_data="$(awk '{print $2}' "$HOME/.ssh/id_ed25519.pub")"
@@ -16,6 +17,7 @@ if [[ -f "$HOME/.ssh/id_ed25519.pub" ]] && command -v gh >/dev/null 2>&1; then
     pending+=("Register SSH key on GitHub: {{ .chezmoi.workingTree }}/scripts/post/setup_github.sh")
   fi
 fi
+{{- end }}
 
 {{ if .useGitea -}}
 if command -v tea >/dev/null 2>&1 && [[ ! -f "$HOME/.config/tea/config.yml" ]]; then

--- a/home/run_once_after_60-ssh-setup.sh.tmpl
+++ b/home/run_once_after_60-ssh-setup.sh.tmpl
@@ -1,3 +1,4 @@
+{{- if .setupGit -}}
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -15,3 +16,4 @@ ssh-keygen -t ed25519 -f "$KEY_PATH" -N "" -C "$(whoami)@$(hostname)"
 echo "==> Generated ed25519 key at $KEY_PATH"
 # A reminder to register it on GitHub is printed at the end of every apply
 # by run_after_99-post-install-checks.sh until the key is actually registered.
+{{- end -}}


### PR DESCRIPTION
If the user opts out of git setup, there's no reason to generate an
ed25519 key or print the GitHub-registration reminder on every apply.
Gate both on `.setupGit` at the template level so the SSH script
renders empty (chezmoi skips empty scripts) and the post-install
check only emits the GitHub pending step when git is enabled.

https://claude.ai/code/session_016wDjCwUUAnJQ1aVMLPbA1D