### PR TITLE
claude/fix-ssh-setup-logic-jAFGK

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -9,4 +9,5 @@ dot_tmux.conf
 {{ if not .setupGit -}}
 .gitconfig
 .config/git/**
+.ssh/config
 {{- end }}


### PR DESCRIPTION
The SSH config points IdentityFile at ~/.ssh/id_ed25519, but PR #22
stopped generating that key when setupGit is false. Deploying a config
that references a missing key produces noise on every ssh invocation,
so gate the config on .setupGit alongside .gitconfig.

https://claude.ai/code/session_01E3X8VyEBimQEyt23c46qXn