### PR TITLE
claude/chezmoi-zsh-autocompletion-HfX3T

### DIFF
--- a/modules/zsh/core.zsh
+++ b/modules/zsh/core.zsh
@@ -81,6 +81,10 @@ if command -v uvx >/dev/null 2>&1; then
   eval "$(uvx --generate-shell-completion zsh)"
 fi
 
+if command -v chezmoi >/dev/null 2>&1; then
+  eval "$(chezmoi completion zsh)"
+fi
+
 if command -v zed >/dev/null 2>&1; then
   export EDITOR="zed --wait"
 else


### PR DESCRIPTION
Source `chezmoi completion zsh` when chezmoi is on PATH, mirroring the
existing pattern used for uv/uvx.