### PR TITLE
Add Claude Code authentication check to post-install

### DIFF
--- a/home/run_after_99-post-install-checks.sh.tmpl
+++ b/home/run_after_99-post-install-checks.sh.tmpl
@@ -25,6 +25,20 @@ if command -v tea >/dev/null 2>&1 && [[ ! -f "$HOME/.config/tea/config.yml" ]]; 
 fi
 {{- end }}
 
+if command -v claude >/dev/null 2>&1; then
+  claude_logged_in=false
+  if [[ -f "$HOME/.claude/.credentials.json" ]]; then
+    claude_logged_in=true
+  {{- if eq .chezmoi.os "darwin" }}
+  elif security find-generic-password -s "Claude Code-credentials" -a "$USER" >/dev/null 2>&1; then
+    claude_logged_in=true
+  {{- end }}
+  fi
+  if [[ "$claude_logged_in" != true ]]; then
+    pending+=("Log in to Claude Code: run 'claude' and authenticate")
+  fi
+fi
+
 if [[ ${#pending[@]} -gt 0 ]]; then
   echo
   echo "==> Post-install steps pending:"


### PR DESCRIPTION
## Summary
Added a post-install check to verify Claude Code authentication status and prompt users to log in if needed.

## Changes
- Added detection for Claude Code CLI tool availability
- Checks for Claude Code credentials in two locations:
  - `~/.claude/.credentials.json` (standard credentials file)
  - macOS Keychain entry "Claude Code-credentials" (platform-specific)
- Adds a pending task to the post-install checklist if the user is not authenticated
- Prompts user to run `claude` command to authenticate

## Implementation Details
- Uses conditional logic to check for credentials file existence
- Includes macOS-specific Keychain lookup using `security find-generic-password`
- Follows existing pattern used for other CLI tools (e.g., `tea`) in the post-install checks
- Only displays the authentication prompt if Claude Code is installed but not logged in

https://claude.ai/code/session_017Dj26qRapiHKTdc1JseC4d