### PR TITLE
setup_gitea.sh: Switch to SSH-based auth instead of API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ scripts/post/                      # post-install helpers (user-invoked)
 Scripts under `scripts/post/` are one-shot tasks the user runs manually (chezmoi can't sensibly drive interactive OAuth-style flows). A checker at the end of every `chezmoi apply` prints a reminder for each pending item until it's done.
 
 - `scripts/post/setup_github.sh` — register `~/.ssh/id_ed25519.pub` on GitHub as both an authentication and signing key. Runs `gh auth login` itself if needed; idempotent on re-run.
-- `scripts/post/setup_gitea.sh` — configure `tea` for a (self-hosted) Gitea instance and register `~/.ssh/id_ed25519.pub` on it via the Gitea REST API. Prompts once for URL + username + token. Re-run per instance.
+- `scripts/post/setup_gitea.sh` — configure `tea` for a (self-hosted) Gitea instance using SSH-based auth. Prints copy-paste-ready values for the instance's SSH key page, waits for you to register the key, then runs `tea login add --ssh-agent-key` so no API token is ever created or stored. Prompts once for URL + username. Re-run per instance.
 
 ## Other reminders
 

--- a/scripts/post/setup_gitea.sh
+++ b/scripts/post/setup_gitea.sh
@@ -1,50 +1,57 @@
 #!/usr/bin/env bash
-# Configure tea (Gitea CLI) for a self-hosted Gitea instance and register
-# ~/.ssh/id_ed25519.pub on the same instance for git push/pull and signing.
-#
-# Generate a personal access token first: Settings → Applications →
-# Generate New Token. Required scopes: write:user, write:public_key.
+# Configure tea (Gitea CLI) for a self-hosted Gitea instance using SSH-based
+# authentication. Prints copy-paste-ready values for Gitea's SSH key settings
+# page and waits for you to register the key, then runs `tea login add` with
+# --ssh-agent-key so no API token is ever created or stored.
 #
 # Re-runnable per instance.
 set -euo pipefail
 
-command -v tea  >/dev/null 2>&1 || { echo "tea CLI not installed" >&2; exit 1; }
-command -v jq   >/dev/null 2>&1 || { echo "jq not installed"      >&2; exit 1; }
-command -v curl >/dev/null 2>&1 || { echo "curl not installed"    >&2; exit 1; }
+command -v tea     >/dev/null 2>&1 || { echo "tea CLI not installed" >&2; exit 1; }
+command -v ssh-add >/dev/null 2>&1 || { echo "ssh-add not installed" >&2; exit 1; }
 
 KEY_PATH="$HOME/.ssh/id_ed25519"
 [[ -f "$KEY_PATH.pub" ]] || { echo "No public key at $KEY_PATH.pub" >&2; exit 1; }
 
-read -r  -p "Gitea URL (e.g. https://gitea.example.com): " url
-read -r  -p "Gitea username: "                              user
-read -rs -p "Gitea API token: "                             token
-echo
-[[ -n "$url" && -n "$user" && -n "$token" ]] || { echo "URL, username, and token are all required" >&2; exit 1; }
+read -r -p "Gitea URL (e.g. https://gitea.example.com): " url
+read -r -p "Gitea username: "                              user
+[[ -n "$url" && -n "$user" ]] || { echo "URL and username are required" >&2; exit 1; }
 
-url="${url%/}"  # drop trailing slash
+# Normalize URL: add https:// if no scheme, drop trailing slash.
+[[ "$url" =~ ^https?:// ]] || url="https://$url"
+url="${url%/}"
 host="${url#http*://}"
 login_name="$user@$host"
 
-echo "==> Adding tea login '$login_name'"
-tea login add --name "$login_name" --url "$url" --user "$user" --token "$token"
-
-# Compare keys by base64 data only — Gitea returns the stored key with type
-# prefix, and pasting via the web UI may include or strip the comment.
 title="$(hostname)"
-pub_key_data="$(awk '{print $2}' "$KEY_PATH.pub")"
-pub_key_full="$(<"$KEY_PATH.pub")"
+pub_key="$(<"$KEY_PATH.pub")"
 
-existing="$(curl -fsS "$url/api/v1/user/keys" \
-                 -H "Authorization: token $token" \
-            | jq -r '.[].key | split(" ")[1]' 2>/dev/null || true)"
+cat <<EOF
 
-if grep -qFx "$pub_key_data" <<<"$existing"; then
-  echo "==> SSH key already registered on $url"
-else
-  curl -fsS -X POST "$url/api/v1/user/keys" \
-       -H "Authorization: token $token" \
-       -H "Content-Type: application/json" \
-       -d "$(jq -n --arg t "$title" --arg k "$pub_key_full" '{title: $t, key: $k}')" \
-       >/dev/null
-  echo "==> Registered SSH key on $url as '$title'"
+==> Register this SSH key on $host before continuing:
+
+    Page:  $url/user/settings/keys
+    Title: $title
+    Key:   $pub_key
+
+EOF
+read -r -p "Press Enter once the key is saved... " _
+
+# tea --ssh-agent-key proves key ownership via ssh-agent, so the agent must be
+# running with our key loaded.
+if ! ssh-add -l >/dev/null 2>&1; then
+  echo "==> Starting ssh-agent"
+  eval "$(ssh-agent -s)" >/dev/null
 fi
+
+fingerprint="$(ssh-keygen -lf "$KEY_PATH.pub" | awk '{print $2}')"
+if ! ssh-add -l 2>/dev/null | grep -qF "$fingerprint"; then
+  ssh-add "$KEY_PATH"
+fi
+
+echo "==> Adding tea login '$login_name' via SSH"
+tea login add \
+  --name "$login_name" \
+  --url "$url" \
+  --user "$user" \
+  --ssh-agent-key "$fingerprint"


### PR DESCRIPTION
## Summary
Refactored `setup_gitea.sh` to use SSH-based authentication with `tea login add --ssh-agent-key` instead of requiring users to create and provide API tokens. This improves security by eliminating the need to store API tokens.

## Key Changes
- **Removed API token requirement**: Users no longer need to generate a personal access token; only URL and username are prompted for
- **Switched to SSH-agent authentication**: Uses `--ssh-agent-key` flag with `tea login add` to authenticate via SSH key ownership proof
- **Manual key registration flow**: Script now prints copy-paste-ready SSH key details and waits for user confirmation after manual registration on the Gitea instance, rather than attempting automated API-based registration
- **Removed API dependencies**: Eliminated `jq` and `curl` dependencies; now only requires `tea` and `ssh-add`
- **SSH agent management**: Automatically starts `ssh-agent` and loads the Ed25519 key if not already present
- **Improved URL handling**: Added automatic `https://` scheme prefix if not provided

## Implementation Details
- Key ownership is verified via SSH fingerprint matching in `ssh-add -l` output
- The script extracts the SSH key fingerprint using `ssh-keygen -lf` and passes it to `tea login add`
- User is guided through the manual registration step with clear instructions including the exact Gitea settings page URL
- All operations remain idempotent and re-runnable per instance

https://claude.ai/code/session_01GmSzy3ytgRsKPfUw5fguwh