### PR TITLE
[codex] link global instructions

### DIFF
--- a/home/dot_codex/symlink_AGENTS.md
+++ b/home/dot_codex/symlink_AGENTS.md
@@ -1,0 +1,1 @@
+../.claude/CLAUDE.md


### PR DESCRIPTION
## Summary
- add a chezmoi symlink source for ~/.codex/AGENTS.md
- point Codex at the existing ~/.claude/CLAUDE.md global instructions so Claude and Codex share one maintained preferences file

## Not included
- no Codex config.toml
- no project trust settings
- no default rules, skills, auth, logs, sessions, histories, caches, memories, plugin caches, worktrees, browser state, sqlite state, or installation IDs

## Validation
- shellcheck over tracked/new shell scripts: no shell scripts in this scoped diff
- chezmoi dry-run apply from a temp HOME
- confirmed chezmoi managed output includes .codex/AGENTS.md