### PR TITLE
Install Codex cask on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Asked at init and cached; re-prompt via `chezmoi init --prompt`.
 | `includePersonalApps` | Bambu Studio, KiCad (macOS only).                        |
 | `installDocker`       | Docker via get.docker.com (Linux only).                  |
 | `installClaudeCode`   | Claude Code via `claude.ai/install.sh` (Linux only; macOS gets it via brew). |
+| `installCodex`        | Codex via Homebrew cask, plus `bubblewrap` apt dependency (Linux only; macOS gets it via brew). |
 | `useGitea`            | Enable the post-install reminder for `scripts/post/setup_gitea.sh`. |
 | `includeClaudeOfficialDevPlugins` | Enable official Claude development plugins such as clangd. |
 | `setupGit`            | Manage `~/.gitconfig` and `~/.config/git/*` (user, SSH signing, global ignore). Off for machines that don't need git. |

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -25,6 +25,7 @@
 {{- $includePersonalApps := false -}}
 {{- $installDocker       := false -}}
 {{- $installClaudeCode   := false -}}
+{{- $installCodex        := false -}}
 
 {{- if eq .chezmoi.os "darwin" -}}
 {{-   if $isDesktop -}}
@@ -37,6 +38,7 @@
 {{- else -}}
 {{-   $installDocker     = promptBoolOnce . "installDocker"     "Install Docker (via get.docker.com)"    true -}}
 {{-   $installClaudeCode = promptBoolOnce . "installClaudeCode" "Install Claude Code (via install.sh)"  true -}}
+{{-   $installCodex      = promptBoolOnce . "installCodex"      "Install Codex (via Homebrew cask)"     true -}}
 {{- end -}}
 
 sourceDir = {{ .chezmoi.workingTree | quote }}
@@ -67,3 +69,4 @@ sourceDir = {{ .chezmoi.workingTree | quote }}
     includePersonalApps = {{ $includePersonalApps }}
     installDocker       = {{ $installDocker }}
     installClaudeCode   = {{ $installClaudeCode }}
+    installCodex        = {{ $installCodex }}

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -25,6 +25,9 @@ packages:
   # `npm i -g @anthropic-ai/claude-code` or Anthropic's installer script.
   linux:
     brews: []
+    casks: []
+    codex_casks:
+      - codex
 
   darwin:
     base:

--- a/home/run_onchange_before_05-linux-apt-prereqs.sh.tmpl
+++ b/home/run_onchange_before_05-linux-apt-prereqs.sh.tmpl
@@ -7,7 +7,12 @@ command -v apt-get >/dev/null 2>&1 || { echo "==> apt-get not available; skippin
 # Homebrew on Linux requires git + a C toolchain; curl is assumed present
 # (it's what bootstrapped chezmoi). zsh goes through apt (not brew) so its
 # path lands in /etc/shells, which chsh requires for run_once_after_70.
-echo "==> Ensuring Linux prereqs (build-essential curl git zsh)"
+apt_packages=(build-essential curl git zsh)
+{{- if .installCodex }}
+apt_packages+=(bubblewrap)
+{{- end }}
+
+echo "==> Ensuring Linux prereqs (${apt_packages[*]})"
 sudo apt-get update
-sudo apt-get install -y build-essential curl git zsh
+sudo apt-get install -y "${apt_packages[@]}"
 {{- end }}

--- a/home/run_onchange_before_20-brew-bundle.sh.tmpl
+++ b/home/run_onchange_before_20-brew-bundle.sh.tmpl
@@ -18,6 +18,14 @@ brew {{ . | quote }}
 {{   range .packages.linux.brews }}
 brew {{ . | quote }}
 {{-  end }}
+{{   range .packages.linux.casks }}
+cask {{ . | quote }}
+{{-  end }}
+{{-  if .installCodex -}}
+{{   range .packages.linux.codex_casks }}
+cask {{ . | quote }}
+{{-  end }}
+{{-  end }}
 {{- end -}}
 {{- if eq .chezmoi.os "darwin" -}}
 {{   range .packages.darwin.base.brews }}


### PR DESCRIPTION
## Summary
- add an installCodex setup toggle for Linux
- render the Linux Codex Homebrew cask only when that toggle is enabled
- install bubblewrap as an apt prereq only when Codex is enabled

## Checks
- chezmoi apply --dry-run --no-tty
- docker run --rm -v /home/eliottteissonniere/Developer/dotfiles:/mnt -w /mnt koalaman/shellcheck:stable -x home/dot_claude/executable_statusline-command.sh scripts/post/setup_gitea.sh scripts/post/setup_github.sh scripts/ssh/import_key.sh
- git diff --check